### PR TITLE
fix: install links

### DIFF
--- a/install-and-build.md
+++ b/install-and-build.md
@@ -5,8 +5,8 @@
 Before you do anything, install Node. It's located at https://nodejs.org/. If you're on Linux, it can be installed through your package
 manager of choice, and [it's on Homebrew on Mac](https://formulae.brew.sh/formula/node). I tested it with Node v20, but v18 should also work.
 
-To install BlockPy, run the installation script. The Windows version is [here](https://raw.githubusercontent.com/JAromando/blockpy-kennel/feat/update-deps-for-modern-node/install/install-and-build.bat)
-and the Linux/Mac version is [here](https://raw.githubusercontent.com/JAromando/blockpy-kennel/feat/update-deps-for-modern-node/install/install-and-build.sh).
+To install BlockPy, run the installation script. The Windows version is [here](https://raw.githubusercontent.com/JAromando/blockpy-kennel/master/install/install-and-build.bat)
+and the Linux/Mac version is [here](https://raw.githubusercontent.com/JAromando/blockpy-kennel/master/install/install-and-build.sh).
 I recommend running this inside a folder, as it will create 3 other folders next to the script when ran.
 
 After it's finished running, it will open a website in your browser. If you can't run any Python code, or an error pops up,

--- a/install/install-and-build.bat
+++ b/install/install-and-build.bat
@@ -52,7 +52,7 @@ cd ../../..
 
 
 : BlockPy
-cd blockpy-edu && git clone https://github.com/THRALLab/blockpy-kennel blockpy && cd blockpy
+cd blockpy-edu && git clone git@github.com:THRALLab/blockpy-kennel.git blockpy && cd blockpy
 call npm install
 call npm run build
 

--- a/install/install-and-build.bat
+++ b/install/install-and-build.bat
@@ -52,8 +52,7 @@ cd ../../..
 
 
 : BlockPy
-cd blockpy-edu && git clone https://github.com/JAromando/blockpy-kennel blockpy && cd blockpy
-git checkout feat/update-deps-for-modern-node
+cd blockpy-edu && git clone https://github.com/THRALLab/blockpy-kennel blockpy && cd blockpy
 call npm install
 call npm run build
 

--- a/install/install-and-build.sh
+++ b/install/install-and-build.sh
@@ -52,7 +52,7 @@ cd ../../..
 
 
 # BlockPy
-cd blockpy-edu && git clone https://github.com/THRALLab/blockpy-kennel blockpy && cd blockpy
+cd blockpy-edu && git clone git@github.com:THRALLab/blockpy-kennel.git blockpy && cd blockpy
 npm install
 npm run build
 

--- a/install/install-and-build.sh
+++ b/install/install-and-build.sh
@@ -52,8 +52,7 @@ cd ../../..
 
 
 # BlockPy
-cd blockpy-edu && git clone https://github.com/JAromando/blockpy-kennel blockpy && cd blockpy
-git checkout feat/update-deps-for-modern-node
+cd blockpy-edu && git clone https://github.com/THRALLab/blockpy-kennel blockpy && cd blockpy
 npm install
 npm run build
 


### PR DESCRIPTION
- Fixed repository links in install scripts pointing to JAromando's account
- Fixed links to install scripts pointing to the PR branch, and don't try checking that branch out either
- Clone using ssh instead of https

Funnily enough even without these changes the script will still work, it's just technically incorrect